### PR TITLE
Request geolocation when settings widget mounts

### DIFF
--- a/src/components/WeatherSettings.jsx
+++ b/src/components/WeatherSettings.jsx
@@ -1,5 +1,14 @@
 import React, { Component, PropTypes } from 'react';
 export default class Weather extends Component {
+
+	componentDidMount() {
+		if (!this.refs.location.value && "geolocation" in navigator) {
+			navigator.geolocation.getCurrentPosition(position => {
+				this.props.onLocationChange(position.coords.latitude + ',' + position.coords.longitude);
+			});
+		}
+	}
+
 	handleLocationChange(e) {
 		const location = this.refs.location;
 		const text = location.value;


### PR DESCRIPTION
If the settings widget location field is empty when the component mounts this addition prompts the user to allow geolocation in the browser. Just sets the value with coordinates but it works for the weather query.

This is a first pass so it might be nicer to grab the city name & country from the location request response and set location to that.
